### PR TITLE
Some suggestions

### DIFF
--- a/bundles/DummyBundle/composer.json
+++ b/bundles/DummyBundle/composer.json
@@ -25,16 +25,7 @@
     "autoload": {
         "psr-4": {
             "Sioweb\\DummyBundle\\": "src/"
-        },
-        "classmap": [
-            "src/Resources/contao/"
-        ],
-        "exclude-from-classmap": [
-            "src/Resources/contao/config/",
-            "src/Resources/contao/dca/",
-            "src/Resources/contao/languages/",
-            "src/Resources/contao/templates/"
-        ]
+        }
     },
     "config": {
         "preferred-install": "dist"

--- a/bundles/DummyBundle/src/ContentElement/ContentDummy.php
+++ b/bundles/DummyBundle/src/ContentElement/ContentDummy.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Sioweb;
-use Contao;
+namespace Sioweb\ContentElement;
+use Contao\ContentElement;
 
-class ContentDummy extends \ContentElement {
+class ContentDummy extends ContentElement {
 
   protected $strTemplate = 'dummy_default';
   

--- a/bundles/DummyBundle/src/Resources/contao/config/config.php
+++ b/bundles/DummyBundle/src/Resources/contao/config/config.php
@@ -17,8 +17,8 @@ if(TL_MODE == 'FE') {
 	// Pfad ggf. anpassen
 	// Alle Dateien in /src/Ressources/public werden unter /web/bundles/bundle-name
 	// als Symlink veröffentlicht nach composer install/update
-	$GLOBALS['TL_CSS'][] = 'web/bundles/contao4dummy/css/dummy.css|static';
-	$GLOBALS['TL_JAVASCRIPT'][] = 'web/bundles/contao4dummy/js/dummy.js|static';
+	$GLOBALS['TL_CSS'][] = 'bundles/contao4dummy/css/dummy.css|static';
+	$GLOBALS['TL_JAVASCRIPT'][] = 'bundles/contao4dummy/js/dummy.js|static';
 }
 
 array_insert($GLOBALS['TL_CTE']['texts'],2,array (

--- a/bundles/DummyBundle/src/Resources/contao/config/config.php
+++ b/bundles/DummyBundle/src/Resources/contao/config/config.php
@@ -22,5 +22,5 @@ if(TL_MODE == 'FE') {
 }
 
 array_insert($GLOBALS['TL_CTE']['texts'],2,array (
-	'content_dummy' => 'Sioweb\ContentDummy',
+	'content_dummy' => 'Sioweb\ContentElement\ContentDummy',
 ));


### PR DESCRIPTION
* If you want to reduce the usage of `Resources/contao` as much as possible, you should not put any classes there at all. Instead, all content element, module, model etc. classes should be in an appropriate namespace of the bundle [1].
* It is not necessary to prefix the bundle asset path with `web/` (I am not even sure if that would even work).

[1] _Note:_ I don't know if there is a true best practice for the namespace names yet. e.g. should it be `Elements` or `Element` or `ContentElement` for content elements for example? In this PR I used the latter.